### PR TITLE
Reapply "Fuse quantize and transform e8m0 scales (#26)" (#27)

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_deepgemm.py
@@ -280,13 +280,6 @@ def deepgemm_fp8_group_blockwise_gemm(
     assert d.stride(-1) == 1
 
     # Transform SFA and SFB into compute-required layout
-    recipe = (1, 128, 128)
-    sfa = fp8_utils.transform_sf_into_required_layout(sfa,
-                                                      mn=m,
-                                                      k=k,
-                                                      recipe=recipe,
-                                                      num_groups=num_groups,
-                                                      is_sfa=True)
 
     deep_gemm.fp8_m_grouped_gemm_nt_masked((a, sfa), (b, sfb),
                                            d,
@@ -453,22 +446,8 @@ class DeepGemmFusedMoE(CutlassFusedMoE):
             masked_m=masked_m,
             expected_m=expected_m,
         )
-        act_input_fp8 = torch.empty(h1.shape[0],
-                                    h1.shape[1],
-                                    h1.shape[2] // 2,
-                                    dtype=torch.float8_e4m3fn,
-                                    device='cuda')
-        act_input_sf = torch.empty(h1.shape[0],
-                                   h1.shape[1],
-                                   h1.shape[2] // 256,
-                                   dtype=torch.float32,
-                                   device='cuda')
-        fp8_utils.silu_and_mul_masked_post_quant_fwd(input=h1,
-                                                     output=act_input_fp8,
-                                                     output_scale=act_input_sf,
-                                                     quant_group_size=128,
-                                                     masked_m=masked_m,
-                                                     scale_ue8m0=True)
+        act_input_fp8, act_input_sf = fp8_utils.silu_and_mul_masked_post_quant_fwd(
+            input=h1, quant_group_size=128, masked_m=masked_m, scale_ue8m0=True)
         h3 = deepgemm_fp8_group_blockwise_gemm(
             a=act_input_fp8,
             b=self.w2_weight,

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -574,13 +574,7 @@ class FP8BlockScalesLinearMethod(LinearMethodBase):
 
         if get_sm_version() == 100:
             import deep_gemm
-            a, a_sf = fp8_utils.per_token_cast_to_fp8_e8m0(input)
-            a_sf = fp8_utils.transform_sf_into_required_layout(a_sf,
-                                                               mn=a.shape[0],
-                                                               k=a.shape[1],
-                                                               recipe=(1, 128,
-                                                                       128),
-                                                               is_sfa=True)
+            a, a_sf = fp8_utils.per_token_quant_and_transform(input)
             output = torch.empty((input.shape[0], module.weight.shape[0]),
                                  device=input.device,
                                  dtype=torch.bfloat16)

--- a/tensorrt_llm/quantization/utils/fp8_utils.py
+++ b/tensorrt_llm/quantization/utils/fp8_utils.py
@@ -166,7 +166,6 @@ def check_sf_layout(sf: torch.Tensor,
 
 
 @nvtx_range("[DG] transform_sf_into_required_layout")
-@torch.compile(dynamic=True)
 def transform_sf_into_required_layout(sf: torch.Tensor,
                                       mn: int,
                                       k: int,

--- a/tensorrt_llm/quantization/utils/fp8_utils.py
+++ b/tensorrt_llm/quantization/utils/fp8_utils.py
@@ -234,10 +234,10 @@ def _silu_and_mul_post_quant_kernel(
     stride_output_scale_1,
     stride_output_scale_2,
     masked_m_ptr,
-    size_n,
+    size_k,
     fp8_max,
     fp8_min,
-    BLOCK_N: tl.constexpr,
+    BLOCK: tl.constexpr,
     NUM_STAGE: tl.constexpr,
     SCALE_UE8M0: tl.constexpr,
 ):
@@ -254,95 +254,110 @@ def _silu_and_mul_post_quant_kernel(
     stride_input_1 = tl.cast(stride_input_1, dtype=tl.int64)
     stride_output_1 = tl.cast(stride_output_1, dtype=tl.int64)
 
-    offs_in_d = hidden_dim_block_index * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_in_d = hidden_dim_block_index * BLOCK + tl.arange(0, BLOCK // 4)
     input_ptr_offs = input_ptr + expert_id * stride_input_0 + offs_in_d
     output_ptr_offs = output_ptr + expert_id * stride_output_0 + offs_in_d
     output_scale_offs = (output_scale_ptr + expert_id * stride_output_scale_0 +
-                         hidden_dim_block_index * stride_output_scale_2)
+                         hidden_dim_block_index * stride_output_scale_1)
 
     for token_index in tl.range(token_id,
                                 token_num_cur_expert,
                                 block_num_per_expert,
                                 num_stages=NUM_STAGE):
-        up = tl.load(
-            input_ptr_offs + token_index * stride_input_1,
-            mask=offs_in_d < size_n,
-            other=0.0,
-        )
-        gate = tl.load(
-            input_ptr_offs + token_index * stride_input_1 + size_n,
-            mask=offs_in_d < size_n,
-            other=0.0,
-        ).to(tl.float32)
-        gate = gate / (1 + tl.exp(-gate))
-        gate = gate.to(input_ptr.dtype.element_ty)
-        gate_up = up * gate
-        _absmax = tl.maximum(tl.max(tl.abs(gate_up)), 1e-10)
-        output_s = _absmax / fp8_max
-        if SCALE_UE8M0:
-            output_s = tl.exp2(tl.ceil(tl.log2(tl.abs(output_s))))
-        output_q = tl.clamp(gate_up / output_s, fp8_min,
-                            fp8_max).to(output_ptr.dtype.element_ty)
+        output_s_int32 = 0
+        for pack_index in tl.range(4):
+            local_mask = offs_in_d + pack_index * 128
+            up = tl.load(
+                input_ptr_offs + token_index * stride_input_1 +
+                pack_index * 128,
+                mask=local_mask < size_k,
+                other=0.0,
+            )
+            gate = tl.load(
+                input_ptr_offs + token_index * stride_input_1 + size_k +
+                pack_index * 128,
+                mask=local_mask < size_k,
+                other=0.0,
+            ).to(tl.float32)
+            gate = gate / (1 + tl.exp(-gate))
+            gate = gate.to(input_ptr.dtype.element_ty)
+            gate_up = up * gate
+            _absmax = tl.maximum(tl.max(tl.abs(gate_up)), 1e-10)
+            output_s = _absmax / fp8_max
+            if SCALE_UE8M0:
+                output_s = tl.exp2(tl.ceil(tl.log2(tl.abs(output_s))))
+            output_q = tl.clamp(gate_up / output_s, fp8_min,
+                                fp8_max).to(output_ptr.dtype.element_ty)
+            output_s_int32 += ((output_s.to(tl.int32, bitcast=True) >> 23) <<
+                               (8 * pack_index))
+            tl.store(
+                output_ptr_offs + token_index * stride_output_1 +
+                pack_index * 128,
+                output_q,
+                mask=local_mask < size_k,
+            )
         tl.store(
-            output_ptr_offs + token_index * stride_output_1,
-            output_q,
-            mask=offs_in_d < size_n,
-        )
-        tl.store(
-            output_scale_offs + token_index * stride_output_scale_1,
-            output_s,
+            output_scale_offs + token_index * stride_output_scale_2,
+            output_s_int32,
         )
 
 
 def silu_and_mul_masked_post_quant_fwd(
     input: torch.Tensor,
-    output: torch.Tensor,
-    output_scale: torch.Tensor,
     quant_group_size: int,
     masked_m: torch.Tensor,
     scale_ue8m0: bool = False,
 ):
     """
-    input shape [expert_num, token_num_padded, hidden_dim]
-    output shape [expert_num, token_num_padded, hidden_dim // 2], dtype fp8
-    output_scale [expert_num token_num_paddded, hidden_dim // 2 // 128] dtype float32
-    quant_group_size  int,
-    masked_m shape [expert_num],
+    input shape [g, m, k]
+    output shape [g, m, k // 2], dtype fp8
+    output_scale [g, k // 4, m // 2 // 128], dtype int32
+    quant_group_size int
+    masked_m shape [g]
     """
 
     assert input.is_contiguous()
-    assert output.dtype == torch.float8_e4m3fn
-    assert output.is_contiguous()
     assert len(input.shape) == 3
     assert input.shape[0] == masked_m.shape[0]
     assert input.shape[-1] % 2 == 0
 
-    size_n = input.shape[-1] // 2
-    assert size_n % quant_group_size == 0
+    # FP8 quantization parameters
+    finfo = torch.finfo(torch.float8_e4m3fn)
+    fp8_max = finfo.max
+    fp8_min = finfo.min
 
+    g, m, k = input.shape
+    k = k // 2
+
+    # Create output
+    output = torch.empty((g, m, k), dtype=torch.float8_e4m3fn, device="cuda")
+
+    # Create output scale
+    alignment = 4
+    scale_k = ceil_div(k, quant_group_size)
+    m_padded = align(m, alignment)
+    scale_k_padded = align(scale_k, alignment)
+    output_scale = torch.zeros((g, scale_k_padded // 4, m_padded),
+                               dtype=torch.int32,
+                               device='cuda')
+
+    # Get block/grid/stage/warp
     expert_num = len(masked_m)
 
     if expert_num < 4:
         BLOCK_NUM_PER_EXPERT = 64
     else:
-        BLOCK_NUM_PER_EXPERT = 32
+        BLOCK_NUM_PER_EXPERT = 128
 
-    BLOCK_N = quant_group_size
+    BLOCK = quant_group_size * 4
     num_warps = 1
     NUM_STAGES = 6
-    hidden_dim_split_block_num = triton.cdiv(size_n, BLOCK_N)
-    assert BLOCK_N % quant_group_size == 0
-
+    hidden_dim_split_block_num = triton.cdiv(k, BLOCK)
     grid = (
         hidden_dim_split_block_num,
         BLOCK_NUM_PER_EXPERT,
         expert_num,
     )
-
-    finfo = torch.finfo(torch.float8_e4m3fn)
-    fp8_max = finfo.max
-    fp8_min = -fp8_max
-
     _silu_and_mul_post_quant_kernel[grid](
         input,
         *input.stride(),
@@ -351,12 +366,166 @@ def silu_and_mul_masked_post_quant_fwd(
         output_scale,
         *output_scale.stride(),
         masked_m,
-        size_n,
+        k,
         fp8_max,
         fp8_min,
-        BLOCK_N=BLOCK_N,
+        BLOCK=BLOCK,
         NUM_STAGE=NUM_STAGES,
         num_warps=num_warps,
         SCALE_UE8M0=scale_ue8m0,
     )
-    return
+    output_scale = output_scale.transpose(1, 2)[:, :m, :]
+    check_sf_layout(
+        output_scale,
+        m,
+        k,
+        (1, 128),
+        g,
+        tma_stride_check=True,
+    )
+    return output, output_scale
+
+
+@triton.jit
+def _per_token_quant_and_transform_kernel(
+    input_ptr,
+    stride_input_0,
+    stride_input_1,
+    output_ptr,
+    stride_output_0,
+    stride_output_1,
+    output_scale_ptr,
+    stride_output_scale_0,
+    stride_output_scale_1,
+    token_num_cur_expert,
+    size_k,
+    fp8_max,
+    fp8_min,
+    BLOCK: tl.constexpr,
+    NUM_STAGE: tl.constexpr,
+    SCALE_UE8M0: tl.constexpr,
+):
+    tl.program_id(2)
+    token_id = tl.program_id(1)
+    hidden_dim_block_index = tl.program_id(0)
+
+    block_num_per_expert = tl.num_programs(1)
+
+    stride_input_0 = tl.cast(stride_input_0, dtype=tl.int64)
+    stride_output_0 = tl.cast(stride_output_0, dtype=tl.int64)
+    stride_input_1 = tl.cast(stride_input_1, dtype=tl.int64)
+    stride_output_1 = tl.cast(stride_output_1, dtype=tl.int64)
+
+    offs_in_d = hidden_dim_block_index * BLOCK + tl.arange(0, BLOCK // 4)
+    input_ptr_offs = input_ptr + offs_in_d
+    output_ptr_offs = output_ptr + offs_in_d
+    output_scale_offs = (output_scale_ptr +
+                         hidden_dim_block_index * stride_output_scale_0)
+
+    for token_index in tl.range(token_id,
+                                token_num_cur_expert,
+                                block_num_per_expert,
+                                num_stages=NUM_STAGE):
+        output_s_int32 = 0
+        for pack_index in tl.range(4):
+            local_mask = offs_in_d + pack_index * 128
+            act = tl.load(
+                input_ptr_offs + token_index * stride_input_0 +
+                pack_index * 128,
+                mask=local_mask < size_k,
+                other=0.0,
+            ).to(tl.float32)
+            _absmax = tl.maximum(tl.max(tl.abs(act)), 1e-10)
+            output_s = _absmax / fp8_max
+            if SCALE_UE8M0:
+                output_s = tl.exp2(tl.ceil(tl.log2(tl.abs(output_s))))
+            output_q = tl.clamp(act / output_s, fp8_min,
+                                fp8_max).to(output_ptr.dtype.element_ty)
+            output_s_int32 += ((output_s.to(tl.int32, bitcast=True) >> 23) <<
+                               (8 * pack_index))
+            tl.store(
+                output_ptr_offs + token_index * stride_output_0 +
+                pack_index * 128,
+                output_q,
+                mask=local_mask < size_k,
+            )
+        tl.store(
+            output_scale_offs + token_index * stride_output_scale_1,
+            output_s_int32,
+        )
+
+
+def per_token_quant_and_transform(
+    input: torch.Tensor,
+    quant_group_size: int = 128,
+    scale_ue8m0: bool = True,
+):
+    """
+    input shape [g, m, k]
+    output shape [g, m, k // 2], dtype fp8
+    output_scale [g, k // 4, m // 2 // 128], dtype int32
+    quant_group_size int
+    masked_m shape [g]
+    """
+
+    assert input.is_contiguous()
+    assert len(input.shape) == 2
+    assert input.shape[-1] % 2 == 0
+
+    # FP8 quantization parameters
+    finfo = torch.finfo(torch.float8_e4m3fn)
+    fp8_max = finfo.max
+    fp8_min = -fp8_max
+
+    m, k = input.shape
+
+    # Create output
+    output = torch.empty((m, k), dtype=torch.float8_e4m3fn, device="cuda")
+
+    # Create output scale
+    alignment = 4
+    scale_k = ceil_div(k, quant_group_size)
+    m_padded = align(m, alignment)
+    scale_k_padded = align(scale_k, alignment)
+    output_scale = torch.zeros((scale_k_padded // 4, m_padded),
+                               dtype=torch.int32,
+                               device='cuda')
+
+    # Get block/grid/stage/warp
+    BLOCK_NUM_PER_EXPERT = 64
+
+    BLOCK = quant_group_size * 4
+    num_warps = 1
+    NUM_STAGES = 6
+    hidden_dim_split_block_num = triton.cdiv(k, BLOCK)
+    grid = (
+        hidden_dim_split_block_num,
+        BLOCK_NUM_PER_EXPERT,
+        1,
+    )
+    _per_token_quant_and_transform_kernel[grid](
+        input,
+        *input.stride(),
+        output,
+        *output.stride(),
+        output_scale,
+        *output_scale.stride(),
+        m,
+        k,
+        fp8_max,
+        fp8_min,
+        BLOCK=BLOCK,
+        NUM_STAGE=NUM_STAGES,
+        num_warps=num_warps,
+        SCALE_UE8M0=scale_ue8m0,
+    )
+    output_scale = output_scale.transpose(0, 1)[:m, :]
+    check_sf_layout(
+        output_scale,
+        m,
+        k,
+        (1, 128),
+        num_groups=None,
+        tma_stride_check=True,
+    )
+    return output, output_scale


### PR DESCRIPTION
This reverts commit 9107cfaa3a3af52b755c05ad1b29474520f7cb6d.

===========================================================
= PERFORMANCE OVERVIEW 
===========================================================
Request Throughput (req/sec):                     8.4155
Total Output Throughput (tokens/sec):             17234.9985
Total Token Throughput (tokens/sec):              25852.4978
Total Latency (ms):                               608399.2393
Average request latency (ms):                     120562.2746
Per User Output Throughput [w/ ctx] (tps/user):   17.0637
Per GPU Output Throughput (tps/gpu):              2154.3748
Average time-to-first-token [TTFT] (ms):          4166.2219
Average time-per-output-token [TPOT] (ms):        56.8618
Per User Output Speed (tps/user):                 17.5976

|Tasks|Version|     Filter     |n-shot|  Metric   |   | Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|------:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |95.1478|±  |0.5918|
|     |       |strict-match    |     5|exact_match|↑  |95.1478|±  |0.5918|

[07/28/2025-14:14:11] [TRT-LLM] [I] lm-eval gsm8k average accuracy: 95.15


@coderabbitai summary

<!--
Please write the PR title by following this template:

[JIRA ticket/NVBugs ID/GitHub issue][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR to support a new feature about cache manager for JIRA ticket TRTLLM-1000, it would be like:

[TRTLLM-1000][feat] Support a new feature about cache manager

Or I have a PR to fix a Llama3 accuracy issue:

[https://nvbugs/1234567][fix] Fix Llama3 accuracy issue
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
