### PR TITLE
[None][feat] change the sparse indices format and update the gatherKvPageOffsetsKe…

### DIFF
--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -292,7 +292,7 @@ bool AttentionOp::convertMMHAParamsToXQAParams(tensorrt_llm::kernels::XQAParams&
     // Parameters for sparse attention
     xqaParams.sparse_attn_indices = mRuntimeSparseAttentionParams.sparse_attn_indices;
     xqaParams.sparse_attn_offsets = mRuntimeSparseAttentionParams.sparse_attn_offsets;
-    xqaParams.use_sparse_attention = useSparseAttention();
+    xqaParams.use_sparse_attention = useTllmGenSparseAttention();
 
     // Cross attention parameters.
     xqaParams.encoder_input_lengths = generationsParams.encoder_input_lengths;
@@ -921,7 +921,7 @@ size_t AttentionOp::getWorkspaceSizeForGeneration(nvinfer1::DataType type, int32
         size_t const cu_kv_seqlens_size = sizeof(int) * (batch_beam + 1);
         size_t const rotary_inv_freq_size = sizeof(float) * batch_beam * mRotaryEmbeddingDim / 2;
         // Two workspaces for sparse attention. One for the sequence lengths, and one for kv block offsets.
-        size_t const sparse_attn_cache_size = useSparseAttention()
+        size_t const sparse_attn_cache_size = useTllmGenSparseAttention()
             ? sizeof(int) * (batch_beam + batch_beam * 2 * max_blocks_per_sequence) * mNumKVHeads
             : 0;
         xqa_workspaces[0] = cu_seqlens_size;

--- a/cpp/tensorrt_llm/common/attentionOp.h
+++ b/cpp/tensorrt_llm/common/attentionOp.h
@@ -358,6 +358,11 @@ public:
         return mUseSparseAttention && mPagedKVCache && mEnableXQA;
     }
 
+    [[nodiscard]] bool useTllmGenSparseAttention() const
+    {
+        return mUseTllmGenSparseAttention && useSparseAttention();
+    }
+
     [[nodiscard]] int smVersion() const
     {
         return mSM;
@@ -436,6 +441,7 @@ public:
     bool mIsGenerationMLA = false;
     bool mUseGenFlashMLA = false;
     bool mUseSparseAttention = false;
+    bool mUseTllmGenSparseAttention = false;
     tensorrt_llm::kernels::MlaMetaParams mMLAParams;
     int mCpSize = 1;
     int mCpRank = 0;

--- a/cpp/tensorrt_llm/kernels/sparseAttentionKernels.cu
+++ b/cpp/tensorrt_llm/kernels/sparseAttentionKernels.cu
@@ -1,9 +1,11 @@
 #include "tensorrt_llm/kernels/sparseAttentionKernels.h"
+#include <cub/cub.cuh>
 
 namespace tensorrt_llm
 {
 namespace kernels
 {
+template <int THREADS_PER_BLOCK>
 __global__ void gatherKvPageOffsetsKernel(
     int32_t* output_kv_page_offsets, // [num_head_kv, batch_size, 2, max_num_pages_per_seq]
     int32_t* output_seq_lengths,     // [num_head_kv, batch_size]
@@ -14,69 +16,84 @@ __global__ void gatherKvPageOffsetsKernel(
     // Each CUDA block processes one sequence from the batch for one head.
     int32_t const head_idx = blockIdx.x;
     int32_t const batch_idx = blockIdx.y;
-    if (batch_idx >= sparse_params.batch_size)
+    int32_t const batch_size = sparse_params.batch_size;
+    if (batch_idx >= batch_size)
     {
         return;
     }
 
-    // Get the range of sparse indices.
+    // Shared memory for reduction.
+    __shared__ typename cub::BlockReduce<Pair, THREADS_PER_BLOCK>::TempStorage temp_storage;
+
+    // Get the range of sparse indices and the sequence length.
     int32_t const start_offset = sparse_params.sparse_attn_offsets[batch_idx];
     int32_t const end_offset = sparse_params.sparse_attn_offsets[batch_idx + 1];
+    int32_t const total_pages = sparse_params.sparse_attn_offsets[batch_size];
     int32_t const num_sparse_pages = end_offset - start_offset;
+    int32_t const original_seq_len = seq_lengths[batch_idx];
+
+    // Get global sparse index.
+    int32_t const sparse_idx_global = head_idx * total_pages + start_offset;
 
     // Get the base memory offset. shape: [batch_size, 2, max_num_pages_per_seq]
     int32_t const max_num_pages_per_seq = sparse_params.max_num_pages_per_seq;
     size_t const src_base_offset = (size_t) batch_idx * 2 * max_num_pages_per_seq;
-    size_t const dst_base_offset
-        = (size_t) head_idx * sparse_params.batch_size * 2 * max_num_pages_per_seq + src_base_offset;
+    size_t const dst_base_offset = (size_t) head_idx * batch_size * 2 * max_num_pages_per_seq + src_base_offset;
 
-    // Initialize sequence length for this head and batch to 0.
-    size_t const seq_len_offset = (size_t) head_idx * sparse_params.batch_size + batch_idx;
-    if (threadIdx.x == 0)
-    {
-        output_seq_lengths[seq_len_offset] = 0;
-    }
-    __syncthreads();
-
-    // Count valid pages and accumulate sequence length as we gather.
-    int32_t const tokens_per_page = sparse_params.tokens_per_page;
-    int32_t const original_seq_len = seq_lengths[batch_idx];
-    int32_t const total_pages = (original_seq_len + tokens_per_page - 1) / tokens_per_page;
+    // Initialize the local max page index and number of valid pages.
+    int32_t local_max_page_index = -1;
+    int32_t local_num_valid_pages = 0;
 
     // Perform the gather operation.
     for (int32_t i = threadIdx.x; i < num_sparse_pages; i += blockDim.x)
     {
         // Get the source idx and offset.
-        int32_t const sparse_idx_global = (start_offset + i) * sparse_params.num_head_kv + head_idx;
-        int32_t const src_idx = sparse_params.sparse_attn_indices[sparse_idx_global];
-        if (src_idx == -1)
+        int32_t const src_idx = sparse_params.sparse_attn_indices[sparse_idx_global + i];
+        if (src_idx < 0)
         {
             continue;
         }
 
-        // Calculate tokens to add for this page
-        int32_t tokens_to_add = tokens_per_page;
-        // Check if this is the last page of the original sequence
-        if (src_idx == total_pages - 1)
-        {
-            // For the last page, only add the remaining tokens
-            int32_t remaining_tokens = original_seq_len - (total_pages - 1) * tokens_per_page;
-            tokens_to_add = remaining_tokens;
-        }
+        // Update the local max page index.
+        local_max_page_index = max(local_max_page_index, src_idx);
+        local_num_valid_pages++;
 
-        // Atomically add tokens to the sequence length
-        atomicAdd(&output_seq_lengths[seq_len_offset], tokens_to_add);
-
+        // Get the source and destination offsets.
         size_t const src_offset_dim0 = src_base_offset + 0 * max_num_pages_per_seq + src_idx;
         size_t const src_offset_dim1 = src_base_offset + 1 * max_num_pages_per_seq + src_idx;
-
-        // Get the destination offset.
         size_t const dst_offset_dim0 = dst_base_offset + 0 * max_num_pages_per_seq + i;
         size_t const dst_offset_dim1 = dst_base_offset + 1 * max_num_pages_per_seq + i;
 
         // Perform the gather operation: read from the sparse location and write to the dense location.
         output_kv_page_offsets[dst_offset_dim0] = kv_page_offsets[src_offset_dim0];
         output_kv_page_offsets[dst_offset_dim1] = kv_page_offsets[src_offset_dim1];
+    }
+
+    // Reduce the local max page indices and number of valid pages.
+    Pair local_pair = {local_max_page_index, local_num_valid_pages};
+    Pair result = cub::BlockReduce<Pair, THREADS_PER_BLOCK>(temp_storage).Reduce(local_pair, PairReduceOp());
+
+    // Update sequence length for this head and batch.
+    if (threadIdx.x == 0)
+    {
+        int32_t const max_page_index = result.max_val;
+        int32_t const num_valid_pages = result.sum_val;
+        int32_t const tokens_per_page = sparse_params.tokens_per_page;
+        int32_t const ori_valid_pages = (original_seq_len + tokens_per_page - 1) / tokens_per_page;
+        size_t const seq_len_offset = (size_t) head_idx * batch_size + batch_idx;
+        if (num_valid_pages > 0)
+        {
+            int32_t seq_len = original_seq_len - (ori_valid_pages - num_valid_pages) * tokens_per_page;
+            if (max_page_index != ori_valid_pages - 1)
+            {
+                seq_len += tokens_per_page - original_seq_len % tokens_per_page;
+            }
+            output_seq_lengths[seq_len_offset] = seq_len;
+        }
+        else
+        {
+            output_seq_lengths[seq_len_offset] = 0;
+        }
     }
 }
 
@@ -89,9 +106,11 @@ void invokeGatherKvPageOffsets(int32_t* output_kv_page_offsets, int32_t* output_
     dim3 grid(sparse_params.num_head_kv, sparse_params.batch_size, 1);
     // The block.
     dim3 block(256, 1, 1);
+    // Shared memory size.
+    size_t smem_size = sizeof(Pair) * 256;
 
     // Launch the kernel.
-    gatherKvPageOffsetsKernel<<<grid, block, 0, stream>>>(
+    gatherKvPageOffsetsKernel<256><<<grid, block, smem_size, stream>>>(
         output_kv_page_offsets, output_seq_lengths, kv_page_offsets, seq_lengths, sparse_params);
 }
 } // namespace kernels

--- a/cpp/tensorrt_llm/kernels/sparseAttentionKernels.h
+++ b/cpp/tensorrt_llm/kernels/sparseAttentionKernels.h
@@ -10,8 +10,8 @@ namespace kernels
 
 struct SparseAttentionParams
 {
-    int32_t* sparse_kv_indices{nullptr};   // [num_sparse_kv_indices, num_kv_heads]
-    int32_t* sparse_attn_indices{nullptr}; // [num_sparse_attn_indices, num_kv_heads]
+    int32_t* sparse_kv_indices{nullptr};   // [num_kv_heads, num_sparse_kv_indices]
+    int32_t* sparse_attn_indices{nullptr}; // [num_kv_heads, num_sparse_attn_indices]
     int32_t* sparse_kv_offsets{nullptr};   // [num_contexts + 1]
     int32_t* sparse_attn_offsets{nullptr}; // [num_generations + 1]
 
@@ -39,6 +39,23 @@ struct SparseAttentionParams
     {
         return std::make_tuple(sparse_kv_indices, sparse_attn_indices, sparse_kv_offsets, sparse_attn_offsets,
             batch_size, num_head_kv, tokens_per_page, max_num_pages_per_seq);
+    }
+};
+
+struct Pair
+{
+    int32_t max_val;
+    int32_t sum_val;
+};
+
+struct PairReduceOp
+{
+    inline __device__ Pair operator()(Pair const& a, Pair const& b) const
+    {
+        Pair result;
+        result.max_val = a.max_val > b.max_val ? a.max_val : b.max_val;
+        result.sum_val = a.sum_val + b.sum_val;
+        return result;
     }
 };
 

--- a/cpp/tensorrt_llm/kernels/sparseAttentionKernels.h
+++ b/cpp/tensorrt_llm/kernels/sparseAttentionKernels.h
@@ -20,6 +20,7 @@ struct SparseAttentionParams
     int32_t num_head_kv{0};
     int32_t tokens_per_page{0};
     int32_t max_num_pages_per_seq{0};
+    int32_t num_sparse_kv_tokens{0};
 
     std::string toString() const
     {
@@ -31,14 +32,15 @@ struct SparseAttentionParams
            << "batch_size: " << this->batch_size << std::endl
            << "num_head_kv: " << this->num_head_kv << std::endl
            << "tokens_per_page: " << this->tokens_per_page << std::endl
-           << "max_num_pages_per_seq: " << this->max_num_pages_per_seq << std::endl;
+           << "max_num_pages_per_seq: " << this->max_num_pages_per_seq << std::endl
+           << "num_sparse_kv_tokens: " << this->num_sparse_kv_tokens << std::endl;
         return ss.str();
     }
 
     auto data() const
     {
         return std::make_tuple(sparse_kv_indices, sparse_attn_indices, sparse_kv_offsets, sparse_attn_offsets,
-            batch_size, num_head_kv, tokens_per_page, max_num_pages_per_seq);
+            batch_size, num_head_kv, tokens_per_page, max_num_pages_per_seq, num_sparse_kv_tokens);
     }
 };
 

--- a/cpp/tensorrt_llm/kernels/unfusedAttentionKernels.h
+++ b/cpp/tensorrt_llm/kernels/unfusedAttentionKernels.h
@@ -150,7 +150,7 @@ struct QKVPreprocessingParams
     int const* cu_kv_seq_lens{nullptr};
     // list of cumulative length of sparse KV indices, of shape {batch_size + 1}
     int const* sparse_kv_offsets{nullptr};
-    // list of sparse KV indices for writing to KV cache, of shape {num_sparse_kv_indices, num_kv_heads}
+    // list of sparse KV indices for writing to KV cache, of shape {num_kv_heads, num_sparse_kv_indices}
     int const* sparse_kv_indices{nullptr};
     // inverse frequencies (angle raised at various powers) from the RoPE formula
     // shape of {batch_size , rotaryEmbeddingDim / 2}
@@ -199,6 +199,8 @@ struct QKVPreprocessingParams
     int q_hidden_size{0};
     int kv_hidden_size{0};
     int hidden_size{0};
+    // Sparse attention
+    int num_sparse_kv_tokens{0};
 
     void setCommonParameters()
     {

--- a/cpp/tensorrt_llm/kernels/unfusedAttentionKernels/unfusedAttentionKernels_2_template.h
+++ b/cpp/tensorrt_llm/kernels/unfusedAttentionKernels/unfusedAttentionKernels_2_template.h
@@ -1741,7 +1741,7 @@ __global__ __launch_bounds__(BLOCK_SIZE) void updateSparseKvCacheAfterFmha(
         if (sparse_token_offset < num_sparse_tokens)
         {
             int const global_sparse_idx = sparse_start_idx + sparse_token_offset;
-            int const sparse_idx_offset = global_sparse_idx * params.kv_head_num + kv_head_idx;
+            int const sparse_idx_offset = kv_head_idx * params.num_sparse_kv_tokens + global_sparse_idx;
 
             int const src_token_idx = params.sparse_kv_indices[sparse_idx_offset];
 
@@ -1766,7 +1766,7 @@ __global__ __launch_bounds__(BLOCK_SIZE) void updateSparseKvCacheAfterFmha(
         if (sparse_token_offset < num_sparse_tokens)
         {
             int const global_sparse_idx = sparse_start_idx + sparse_token_offset;
-            int const sparse_idx_offset = global_sparse_idx * params.kv_head_num + kv_head_idx;
+            int const sparse_idx_offset = kv_head_idx * params.num_sparse_kv_tokens + global_sparse_idx;
 
             int const src_token_idx = params.sparse_kv_indices[sparse_idx_offset];
             int const dst_token_idx = sparse_token_offset;

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -222,6 +222,7 @@ public:
         op.mRuntimeSparseAttentionParams.sparse_kv_indices = nullptr;
         op.mRuntimeSparseAttentionParams.sparse_attn_offsets = nullptr;
         op.mRuntimeSparseAttentionParams.sparse_attn_indices = nullptr;
+        op.mRuntimeSparseAttentionParams.num_sparse_kv_tokens = 0;
 
         if (op.useSparseAttention() && num_seqs > 0)
         {
@@ -231,6 +232,8 @@ public:
                 {
                     op.mRuntimeSparseAttentionParams.sparse_kv_indices = sparse_kv_indices.value().data_ptr<int32_t>();
                     op.mRuntimeSparseAttentionParams.sparse_kv_offsets = sparse_kv_offsets.value().data_ptr<int32_t>();
+                    op.mRuntimeSparseAttentionParams.num_sparse_kv_tokens
+                        = sparse_kv_offsets.value().index({num_seqs}).item<int32_t>();
                 }
             }
             else
@@ -675,6 +678,10 @@ void attention(torch::Tensor q, torch::optional<torch::Tensor> k, torch::optiona
         || (sparse_attn_indices.has_value() && sparse_attn_indices.value().numel() > 0))
     {
         op->mUseSparseAttention = true;
+        if (sparse_attn_indices.has_value() && sparse_attn_indices.value().numel() > 0)
+        {
+            op->mUseTllmGenSparseAttention = true;
+        }
     }
 
     if (is_mla_enable)

--- a/cpp/tests/unit_tests/kernels/sparseAttentionKernelsTest.cpp
+++ b/cpp/tests/unit_tests/kernels/sparseAttentionKernelsTest.cpp
@@ -75,7 +75,7 @@ TEST_F(sparseAttentionKernelsTest, GatherKvPageOffsetsKernelTest)
             for (int p = 0; p < max_num_pages_per_seq; ++p)
             {
                 int offset = b * 2 * max_num_pages_per_seq + d * max_num_pages_per_seq + p;
-                kv_page_offsets_ptr[offset] = 1000 + b * 100 + d * 10 + p; // Test pattern
+                kv_page_offsets_ptr[offset] = 1000 + b * 100 + d * 10 + p;
             }
         }
     }
@@ -93,7 +93,7 @@ TEST_F(sparseAttentionKernelsTest, GatherKvPageOffsetsKernelTest)
     {
         for (int head = 0; head < num_head_kv; ++head)
         {
-            int idx = page * num_head_kv + head;
+            int idx = head * num_sparse_pages + page;
             sparse_indices_ptr[idx] = sparse_page_indices[page][head];
         }
     }
@@ -170,7 +170,8 @@ TEST_F(sparseAttentionKernelsTest, GatherKvPageOffsetsKernelTest)
                 {
                     // Calculate expected value (from the sparse index)
                     int sparse_idx_global = sparse_indices_offsets_ptr[b] + p;
-                    int src_page_idx = sparse_indices_ptr[sparse_idx_global * num_head_kv + h];
+                    int src_page_idx
+                        = sparse_indices_ptr[h * sparse_indices_offsets_ptr[batch_size] + sparse_idx_global];
 
                     if (src_page_idx == -1)
                     {

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1242,6 +1242,8 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             if sparse_attn_indices is not None:
                 sparse_attn_indices, sparse_attn_offsets = convert_token_to_page_sparse_indices(
                     sparse_attn_indices, sparse_attn_offsets, metadata)
+                sparse_attn_indices = sparse_attn_indices.transpose(
+                    0, 1).contiguous()
 
         self.wrapper.plan(
             layer_idx=self.get_local_layer_idx(metadata),

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1239,6 +1239,10 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         if self.sparse_attention_config is not None:
             sparse_kv_indices, sparse_kv_offsets, sparse_attn_indices, sparse_attn_offsets = self.sparse_attention_predict(
                 q, k, metadata)
+            sparse_attn_indices, sparse_attn_offsets = None, None
+            if sparse_kv_indices is not None:
+                sparse_kv_indices = sparse_kv_indices.transpose(0,
+                                                                1).contiguous()
             if sparse_attn_indices is not None:
                 sparse_attn_indices, sparse_attn_offsets = convert_token_to_page_sparse_indices(
                     sparse_attn_indices, sparse_attn_offsets, metadata)


### PR DESCRIPTION
…rnel.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
