### PR TITLE
[None][feat] fuse convert into the gather offset kernel

### DIFF
--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -291,6 +291,7 @@ bool AttentionOp::convertMMHAParamsToXQAParams(tensorrt_llm::kernels::XQAParams&
     // Parameters for sparse attention
     xqaParams.sparse_attn_indices = mRuntimeSparseAttentionParams.sparse_attn_indices;
     xqaParams.sparse_attn_offsets = mRuntimeSparseAttentionParams.sparse_attn_offsets;
+    xqaParams.sparse_attn_indices_block_size = mRuntimeSparseAttentionParams.sparse_attn_indices_block_size.value_or(1);
     xqaParams.use_sparse_attention = useTllmGenSparseAttention();
 
     // Cross attention parameters.

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/xqaParams.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/xqaParams.h
@@ -112,6 +112,7 @@ struct XQAParams
     // sparse attention parameters
     int32_t* sparse_attn_indices = nullptr;
     int32_t* sparse_attn_offsets = nullptr;
+    int32_t sparse_attn_indices_block_size = 1;
     bool use_sparse_attention = false;
 
     cudaStream_t stream = 0;
@@ -186,6 +187,7 @@ struct XQAParams
            << "encoder_input_lengths: " << encoder_input_lengths << std::endl
            << "sparse_attn_indices :" << sparse_attn_indices << std ::endl
            << "sparse_attn_offsets :" << sparse_attn_offsets << std ::endl
+           << "sparse_attn_indices_block_size :" << sparse_attn_indices_block_size << std ::endl
            << "use_sparse_attention :" << (use_sparse_attention ? "true" : "false") << std ::endl
            << "stream :" << stream;
 

--- a/cpp/tensorrt_llm/kernels/sparseAttentionKernels.cu
+++ b/cpp/tensorrt_llm/kernels/sparseAttentionKernels.cu
@@ -5,7 +5,7 @@ namespace tensorrt_llm
 {
 namespace kernels
 {
-template <int THREADS_PER_BLOCK>
+template <int THREADS_PER_BLOCK, int MAX_NUM_PAGES>
 __global__ void gatherKvPageOffsetsKernel(
     int32_t* output_kv_page_offsets, // [num_head_kv, batch_size, 2, max_num_pages_per_seq]
     int32_t* output_seq_lengths,     // [num_head_kv, batch_size]
@@ -17,13 +17,20 @@ __global__ void gatherKvPageOffsetsKernel(
     int32_t const head_idx = blockIdx.x;
     int32_t const batch_idx = blockIdx.y;
     int32_t const batch_size = sparse_params.batch_size;
+    int32_t const tokens_per_page = sparse_params.tokens_per_page;
+    int32_t const indices_block_size = sparse_params.sparse_attn_indices_block_size.value_or(1);
     if (batch_idx >= batch_size)
     {
         return;
     }
 
     // Shared memory for reduction.
-    __shared__ typename cub::BlockReduce<Pair, THREADS_PER_BLOCK>::TempStorage temp_storage;
+    using BlockScan = cub::BlockScan<int32_t, THREADS_PER_BLOCK>;
+    using BlockReduce = cub::BlockReduce<Pair, THREADS_PER_BLOCK>;
+    __shared__ typename BlockScan::TempStorage temp_storage_scan;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+    __shared__ int32_t s_page_mask[MAX_NUM_PAGES];
+    __shared__ int32_t s_cu_page_mask[MAX_NUM_PAGES];
 
     // Get the range of sparse indices and the sequence length.
     int32_t const start_offset = sparse_params.sparse_attn_offsets[batch_idx];
@@ -31,6 +38,8 @@ __global__ void gatherKvPageOffsetsKernel(
     int32_t const total_pages = sparse_params.sparse_attn_offsets[batch_size];
     int32_t const num_sparse_pages = end_offset - start_offset;
     int32_t const original_seq_len = seq_lengths[batch_idx];
+    int32_t const ori_valid_pages = (original_seq_len + tokens_per_page - 1) / tokens_per_page;
+    int32_t const page_loops = (ori_valid_pages + MAX_NUM_PAGES - 1) / MAX_NUM_PAGES;
 
     // Get global sparse index.
     int32_t const sparse_idx_global = head_idx * total_pages + start_offset;
@@ -44,42 +53,73 @@ __global__ void gatherKvPageOffsetsKernel(
     int32_t local_max_page_index = -1;
     int32_t local_num_valid_pages = 0;
 
-    // Perform the gather operation.
-    for (int32_t i = threadIdx.x; i < num_sparse_pages; i += blockDim.x)
+    // Calculate the page mask.
+    int32_t src_page_idx_offset = 0;
+    int32_t dst_page_idx_offset = 0;
+    for (int32_t i = 0; i < page_loops; i++)
     {
-        // Get the source idx and offset.
-        int32_t const src_idx = sparse_params.sparse_attn_indices[sparse_idx_global + i];
-        if (src_idx < 0)
+        src_page_idx_offset = i * MAX_NUM_PAGES;
+        int32_t loop_num_valid_pages = min(MAX_NUM_PAGES, ori_valid_pages - src_page_idx_offset);
+        for (int32_t j = threadIdx.x; j < loop_num_valid_pages; j += blockDim.x)
         {
-            continue;
+            s_page_mask[i] = 0;
         }
+        __syncthreads();
 
-        // Update the local max page index.
-        local_max_page_index = max(local_max_page_index, src_idx);
-        local_num_valid_pages++;
+        for (int32_t j = threadIdx.x; j < num_sparse_pages; j += blockDim.x)
+        {
+            int32_t const src_idx = sparse_params.sparse_attn_indices[sparse_idx_global + j];
+            if (src_idx < 0)
+            {
+                continue;
+            }
+            int32_t const src_page_idx = src_idx * indices_block_size / tokens_per_page;
+            if (src_page_idx >= src_page_idx_offset && src_page_idx < src_page_idx_offset + loop_num_valid_pages)
+            {
+                s_page_mask[src_page_idx - src_page_idx_offset] = 1;
+            }
+        }
+        __syncthreads();
 
-        // Get the source and destination offsets.
-        size_t const src_offset_dim0 = src_base_offset + 0 * max_num_pages_per_seq + src_idx;
-        size_t const src_offset_dim1 = src_base_offset + 1 * max_num_pages_per_seq + src_idx;
-        size_t const dst_offset_dim0 = dst_base_offset + 0 * max_num_pages_per_seq + i;
-        size_t const dst_offset_dim1 = dst_base_offset + 1 * max_num_pages_per_seq + i;
+        BlockScan(temp_storage_scan).ExclusiveSum(s_page_mask, s_cu_page_mask);
 
-        // Perform the gather operation: read from the sparse location and write to the dense location.
-        output_kv_page_offsets[dst_offset_dim0] = kv_page_offsets[src_offset_dim0];
-        output_kv_page_offsets[dst_offset_dim1] = kv_page_offsets[src_offset_dim1];
+        // Perform the gather operation.
+        for (int32_t i = threadIdx.x; i < loop_num_valid_pages; i += blockDim.x)
+        {
+            if (s_page_mask[i] == 0)
+            {
+                continue;
+            }
+            // Get the source and destination offsets.
+            int32_t const src_idx = src_page_idx_offset + i;
+            int32_t const dst_idx = dst_page_idx_offset + s_cu_page_mask[i];
+
+            // Update the local max page index.
+            local_max_page_index = max(local_max_page_index, src_idx);
+            local_num_valid_pages++;
+
+            // Get the source and destination offsets.
+            size_t const src_offset_dim0 = src_base_offset + 0 * max_num_pages_per_seq + src_idx;
+            size_t const src_offset_dim1 = src_base_offset + 1 * max_num_pages_per_seq + src_idx;
+            size_t const dst_offset_dim0 = dst_base_offset + 0 * max_num_pages_per_seq + dst_idx;
+            size_t const dst_offset_dim1 = dst_base_offset + 1 * max_num_pages_per_seq + dst_idx;
+
+            // Perform the gather operation: read from the sparse location and write to the dense location.
+            output_kv_page_offsets[dst_offset_dim0] = kv_page_offsets[src_offset_dim0];
+            output_kv_page_offsets[dst_offset_dim1] = kv_page_offsets[src_offset_dim1];
+        }
+        dst_page_idx_offset += s_cu_page_mask[loop_num_valid_pages - 1];
     }
 
     // Reduce the local max page indices and number of valid pages.
     Pair local_pair = {local_max_page_index, local_num_valid_pages};
-    Pair result = cub::BlockReduce<Pair, THREADS_PER_BLOCK>(temp_storage).Reduce(local_pair, PairReduceOp());
+    Pair result = BlockReduce(temp_storage).Reduce(local_pair, PairReduceOp());
 
     // Update sequence length for this head and batch.
     if (threadIdx.x == 0)
     {
         int32_t const max_page_index = result.max_val;
         int32_t const num_valid_pages = result.sum_val;
-        int32_t const tokens_per_page = sparse_params.tokens_per_page;
-        int32_t const ori_valid_pages = (original_seq_len + tokens_per_page - 1) / tokens_per_page;
         size_t const seq_len_offset = (size_t) head_idx * batch_size + batch_idx;
         if (num_valid_pages > 0)
         {
@@ -107,10 +147,10 @@ void invokeGatherKvPageOffsets(int32_t* output_kv_page_offsets, int32_t* output_
     // The block.
     dim3 block(256, 1, 1);
     // Shared memory size.
-    size_t smem_size = sizeof(Pair) * 256;
+    size_t smem_size = sizeof(Pair) * 256 + sizeof(int32_t) * (512 * 2 + 256);
 
     // Launch the kernel.
-    gatherKvPageOffsetsKernel<256><<<grid, block, smem_size, stream>>>(
+    gatherKvPageOffsetsKernel<256, 512><<<grid, block, smem_size, stream>>>(
         output_kv_page_offsets, output_seq_lengths, kv_page_offsets, seq_lengths, sparse_params);
 }
 } // namespace kernels

--- a/cpp/tensorrt_llm/kernels/sparseAttentionKernels.h
+++ b/cpp/tensorrt_llm/kernels/sparseAttentionKernels.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cuda_runtime.h>
+#include <optional>
 #include <sstream>
 
 namespace tensorrt_llm
@@ -21,6 +22,8 @@ struct SparseAttentionParams
     int32_t tokens_per_page{0};
     int32_t max_num_pages_per_seq{0};
     int32_t num_sparse_kv_tokens{0};
+    // Indices block size is the number of tokens corresponding to each sparse index
+    std::optional<int32_t> sparse_attn_indices_block_size{std::nullopt};
 
     std::string toString() const
     {
@@ -33,7 +36,8 @@ struct SparseAttentionParams
            << "num_head_kv: " << this->num_head_kv << std::endl
            << "tokens_per_page: " << this->tokens_per_page << std::endl
            << "max_num_pages_per_seq: " << this->max_num_pages_per_seq << std::endl
-           << "num_sparse_kv_tokens: " << this->num_sparse_kv_tokens << std::endl;
+           << "num_sparse_kv_tokens: " << this->num_sparse_kv_tokens << std::endl
+           << "sparse_attn_indices_block_size: " << this->sparse_attn_indices_block_size.value_or(1) << std::endl;
         return ss.str();
     }
 

--- a/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
+++ b/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
@@ -433,6 +433,7 @@ void XqaDispatcher::runImpl(
                 sparse_params.num_head_kv = num_kv_heads;
                 sparse_params.tokens_per_page = kv_cache_buffer.mTokensPerBlock;
                 sparse_params.max_num_pages_per_seq = kv_cache_buffer.mMaxBlocksPerSeq;
+                sparse_params.sparse_attn_indices_block_size = params.sparse_attn_indices_block_size;
                 invokeGatherKvPageOffsets(reinterpret_cast<int32_t*>(launchParams.sparse_kv_block_offsets),
                     launchParams.sparse_seq_lengths, reinterpret_cast<int32_t const*>(kv_cache_buffer.data),
                     params.sequence_lengths, sparse_params, params.stream);

--- a/cpp/tensorrt_llm/nanobind/thop/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/thop/bindings.cpp
@@ -51,7 +51,8 @@ void initBindings(nb::module_& m)
         nb::arg("mrope_rotary_cos_sin") = std::nullopt, nb::arg("mrope_position_deltas") = std::nullopt,
         nb::arg("attention_chunk_size") = std::nullopt, nb::arg("softmax_stats_tensor") = std::nullopt,
         nb::arg("spec_decoding_bool_params"), nb::arg("spec_decoding_tensor_params"),
-        nb::arg("sparse_attention_params") = std::nullopt, "Multi-head attention operation",
+        nb::arg("sparse_attention_params") = std::nullopt, 
+        nb::arg("sparse_attn_indices_block_size") = std::nullopt, "Multi-head attention operation",
         nb::call_guard<nb::gil_scoped_release>());
 }
 } // namespace tensorrt_llm::nanobind::thop

--- a/cpp/tensorrt_llm/nanobind/thop/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/thop/bindings.cpp
@@ -51,8 +51,7 @@ void initBindings(nb::module_& m)
         nb::arg("mrope_rotary_cos_sin") = std::nullopt, nb::arg("mrope_position_deltas") = std::nullopt,
         nb::arg("attention_chunk_size") = std::nullopt, nb::arg("softmax_stats_tensor") = std::nullopt,
         nb::arg("spec_decoding_bool_params"), nb::arg("spec_decoding_tensor_params"),
-        nb::arg("sparse_attention_params") = std::nullopt, 
-        nb::arg("sparse_attn_indices_block_size") = std::nullopt, "Multi-head attention operation",
-        nb::call_guard<nb::gil_scoped_release>());
+        nb::arg("sparse_attention_params") = std::nullopt, nb::arg("sparse_attn_indices_block_size") = std::nullopt,
+        "Multi-head attention operation", nb::call_guard<nb::gil_scoped_release>());
 }
 } // namespace tensorrt_llm::nanobind::thop

--- a/cpp/tensorrt_llm/pybind/thop/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/thop/bindings.cpp
@@ -51,9 +51,7 @@ void initBindings(pybind11::module_& m)
         py::arg("mrope_rotary_cos_sin") = std::nullopt, py::arg("mrope_position_deltas") = std::nullopt,
         py::arg("attention_chunk_size") = std::nullopt, py::arg("softmax_stats_tensor") = std::nullopt,
         py::arg("spec_decoding_bool_params"), py::arg("spec_decoding_tensor_params"),
-        py::arg("sparse_attention_params") = std::nullopt, 
-        py::arg("sparse_attn_indices_block_size") = std::nullopt, 
-        "Multi-head attention operation",
-        py::call_guard<py::gil_scoped_release>());
+        py::arg("sparse_attention_params") = std::nullopt, py::arg("sparse_attn_indices_block_size") = std::nullopt,
+        "Multi-head attention operation", py::call_guard<py::gil_scoped_release>());
 }
 } // namespace tensorrt_llm::pybind::thop

--- a/cpp/tensorrt_llm/pybind/thop/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/thop/bindings.cpp
@@ -51,7 +51,9 @@ void initBindings(pybind11::module_& m)
         py::arg("mrope_rotary_cos_sin") = std::nullopt, py::arg("mrope_position_deltas") = std::nullopt,
         py::arg("attention_chunk_size") = std::nullopt, py::arg("softmax_stats_tensor") = std::nullopt,
         py::arg("spec_decoding_bool_params"), py::arg("spec_decoding_tensor_params"),
-        py::arg("sparse_attention_params") = std::nullopt, "Multi-head attention operation",
+        py::arg("sparse_attention_params") = std::nullopt, 
+        py::arg("sparse_attn_indices_block_size") = std::nullopt, 
+        "Multi-head attention operation",
         py::call_guard<py::gil_scoped_release>());
 }
 } // namespace tensorrt_llm::pybind::thop

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -542,7 +542,8 @@ void attention(torch::Tensor q, torch::optional<torch::Tensor> k, torch::optiona
     std::optional<torch::Tensor> mrope_rotary_cos_sin, std::optional<torch::Tensor> mrope_position_deltas,
     std::optional<int64_t> attention_chunk_size, std::optional<torch::Tensor> softmax_stats_tensor,
     std::vector<bool> spec_decoding_bool_params, std::vector<std::optional<torch::Tensor>> spec_decoding_tensor_params,
-    std::vector<torch::optional<torch::Tensor>> sparse_attention_params)
+    std::vector<torch::optional<torch::Tensor>> sparse_attention_params,
+    std::optional<int64_t> sparse_attn_indices_block_size)
 {
     // Decompress attention config parameters
     TORCH_CHECK(attention_config_params.size() == 12, "Expected 12 attention config parameters");
@@ -691,6 +692,7 @@ void attention(torch::Tensor q, torch::optional<torch::Tensor> k, torch::optiona
         if (sparse_attn_indices.has_value() && sparse_attn_indices.value().numel() > 0)
         {
             op->mUseTllmGenSparseAttention = true;
+            op->mRuntimeSparseAttentionParams.sparse_attn_indices_block_size = sparse_attn_indices_block_size;
         }
     }
 

--- a/cpp/tensorrt_llm/thop/attentionOp.h
+++ b/cpp/tensorrt_llm/thop/attentionOp.h
@@ -57,6 +57,7 @@ void attention(torch::Tensor q, torch::optional<torch::Tensor> k, torch::optiona
     std::optional<torch::Tensor> mrope_rotary_cos_sin, std::optional<torch::Tensor> mrope_position_deltas,
     std::optional<int64_t> attention_chunk_size, std::optional<torch::Tensor> softmax_stats_tensor,
     std::vector<bool> spec_decoding_bool_params, std::vector<std::optional<torch::Tensor>> spec_decoding_tensor_params,
-    std::vector<torch::optional<torch::Tensor>> sparse_attention_params);
+    std::vector<torch::optional<torch::Tensor>> sparse_attention_params,
+    std::optional<int64_t> sparse_attn_indices_block_size);
 
 } // namespace torch_ext

--- a/cpp/tests/unit_tests/kernels/sparseAttentionKernelsTest.cpp
+++ b/cpp/tests/unit_tests/kernels/sparseAttentionKernelsTest.cpp
@@ -117,6 +117,7 @@ TEST_F(sparseAttentionKernelsTest, GatherKvPageOffsetsKernelTest)
     sparse_params.num_head_kv = num_head_kv;
     sparse_params.tokens_per_page = tokens_per_page;
     sparse_params.max_num_pages_per_seq = max_num_pages_per_seq;
+    sparse_params.sparse_attn_indices_block_size = tokens_per_page;
 
     // Launch the kernel
     invokeGatherKvPageOffsets(bufferCast<int32_t>(*output_kv_page_offsets), bufferCast<int32_t>(*output_seq_lengths),

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -545,82 +545,6 @@ class TrtllmAttentionWrapper:
         )
 
 
-@torch.compile(dynamic=True)
-def convert_token_to_page_sparse_indices(
-        sparse_attn_indices: torch.Tensor, sparse_attn_offsets: torch.Tensor,
-        metadata: 'TrtllmAttentionMetadata'
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Convert token-based sparse attention indices to page-based sparse attention indices.
-
-    Args:
-        sparse_attn_indices: Token-based indices with shape [num_tokens, num_kv_heads]
-        sparse_attn_offsets: Offsets with shape [batch_size+1] indicating token boundaries for each batch
-        metadata: Attention metadata containing tokens_per_block (page_size)
-
-    Returns:
-        Tuple of (page_indices, page_offsets):
-        - page_indices: Page-based indices with shape [num_pages, num_kv_heads]
-        - page_offsets: Updated offsets with shape [batch_size+1] indicating page boundaries for each batch
-
-    Example:
-        If sparse_attn_indices first dimension is [1, 30, 67] and page_size=32,
-        the result will be [0, 2] (token 1 -> page 0, token 30 -> page 0, token 67 -> page 2)
-    """
-    page_size = metadata.tokens_per_block
-    batch_size = sparse_attn_offsets.size(0) - 1
-    num_kv_heads = sparse_attn_indices.size(1)
-
-    # Convert token indices to page indices
-    page_indices = sparse_attn_indices // page_size
-
-    # Process each batch and each kv_head separately to remove duplicates
-    new_page_indices_list = []
-    new_offsets = torch.zeros_like(sparse_attn_offsets)
-
-    current_offset = 0
-    for batch_idx in range(batch_size):
-        start_idx = sparse_attn_offsets[batch_idx]
-        end_idx = sparse_attn_offsets[batch_idx + 1]
-
-        if start_idx >= end_idx:
-            # Empty batch
-            new_offsets[batch_idx + 1] = current_offset
-            continue
-
-        batch_page_indices = page_indices[
-            start_idx:end_idx]  # [num_tokens_in_batch, num_kv_heads]
-
-        # For each kv_head, remove duplicates while preserving order
-        batch_unique_pages = []
-        for head_idx in range(num_kv_heads):
-            head_pages = batch_page_indices[:, head_idx]
-            unique_pages = torch.unique(head_pages, sorted=False)
-            batch_unique_pages.append(unique_pages)
-
-        # Find the maximum length among all heads for this batch
-        max_len = max(pages.size(0) for pages in batch_unique_pages)
-
-        if max_len > 0:
-            batch_result = torch.full((max_len, num_kv_heads),
-                                      fill_value=-1,
-                                      dtype=page_indices.dtype,
-                                      device=page_indices.device)
-
-            for head_idx in range(num_kv_heads):
-                unique_pages = batch_unique_pages[head_idx]
-                batch_result[:unique_pages.size(0), head_idx] = unique_pages
-
-            new_page_indices_list.append(batch_result)
-            current_offset += max_len
-
-        new_offsets[batch_idx + 1] = current_offset
-
-    new_page_indices = torch.cat(new_page_indices_list, dim=0)
-
-    return new_page_indices, new_offsets
-
-
 @dataclass(kw_only=True)
 class TrtllmAttentionMetadata(AttentionMetadata):
     workspace: Optional[torch.Tensor] = None
@@ -1352,10 +1276,7 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 q, k, metadata)
             sparse_attn_indices_block_size = self.sparse_attention_config.get_sparse_indices_block_size(
             )
-
             if sparse_attn_indices is not None:
-                sparse_attn_indices, sparse_attn_offsets = convert_token_to_page_sparse_indices(
-                    sparse_attn_indices, sparse_attn_offsets, metadata)
                 sparse_attn_indices = sparse_attn_indices.transpose(
                     0, 1).contiguous()
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -163,6 +163,9 @@ class SparseAttentionBaseConfig(BaseModel):
         """
         return True
 
+    def get_sparse_indices_block_size(self) -> int:
+        return 1
+
 
 class RocketSparseAttentionConfig(SparseAttentionBaseConfig):
     """


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
