### PR TITLE
[None][fix] update trtllm sparse attention interface

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
@@ -126,8 +126,11 @@ class RocketTrtllmAttention(TrtllmAttention):
         self.page_size = sparse_attention_config.page_size
 
     def sparse_attn_predict(
-        self, q: torch.Tensor, k: torch.Tensor,
-        metadata: RocketTrtllmAttentionMetadata
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        metadata: TrtllmAttentionMetadata,
+        **kwargs,
     ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
         """
         Predict sparse attention indices.
@@ -138,14 +141,12 @@ class RocketTrtllmAttention(TrtllmAttention):
             - sparse_attn_indices: [total_selected_indices, num_kv_heads]
             - sparse_attn_offsets: [batch_size + 1] with cumulative indices count
         """
-        q, k, _ = q.split([
-            self.num_heads * self.head_dim, self.num_kv_heads * self.head_dim,
-            self.num_kv_heads * self.head_dim
-        ],
-                          dim=-1)
-
-        if k is None or metadata is None:
-            return None, None
+        if k is None:
+            q, k, _ = q.split([
+                self.num_heads * self.head_dim, self.num_kv_heads *
+                self.head_dim, self.num_kv_heads * self.head_dim
+            ],
+                              dim=-1)
 
         num_contexts = metadata.num_contexts
         num_generations = metadata.num_generations
@@ -200,8 +201,11 @@ class RocketTrtllmAttention(TrtllmAttention):
         return sparse_attn_indices, sparse_attn_offsets
 
     def sparse_kv_predict(
-        self, q: torch.Tensor, k: torch.Tensor,
-        metadata: RocketTrtllmAttentionMetadata
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        metadata: TrtllmAttentionMetadata,
+        **kwargs,
     ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
         """
         Predict sparse kv indices.
@@ -213,14 +217,12 @@ class RocketTrtllmAttention(TrtllmAttention):
             - flattened_indices: [total_selected_indices, num_kv_heads]
             - batch_offsets: [batch_size + 1] with cumulative indices count
         """
-        q, k, _ = q.split([
-            self.num_heads * self.head_dim, self.num_kv_heads * self.head_dim,
-            self.num_kv_heads * self.head_dim
-        ],
-                          dim=-1)
-
-        if k is None or metadata is None:
-            return None, None
+        if k is None:
+            q, k, _ = q.split([
+                self.num_heads * self.head_dim, self.num_kv_heads *
+                self.head_dim, self.num_kv_heads * self.head_dim
+            ],
+                              dim=-1)
 
         num_contexts = metadata.num_contexts
         num_generations = metadata.num_generations

--- a/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
@@ -125,19 +125,91 @@ class RocketTrtllmAttention(TrtllmAttention):
         self.kernel_size = sparse_attention_config.kernel_size
         self.page_size = sparse_attention_config.page_size
 
-    def sparse_attention_predict(
+    def sparse_attn_predict(
         self, q: torch.Tensor, k: torch.Tensor,
         metadata: RocketTrtllmAttentionMetadata
     ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
         """
-        Predict sparse KV indices and sparse attention indices for the input sequence.
-
+        Predict sparse attention indices.
         For RocketKV:
-        - Context phase: predict SnapKV sparse kv indices
         - Generation phase: predict RocketKV sparse attention indices
 
         Returns:
-            Tuple of (flattened_indices, batch_offsets)
+            - sparse_attn_indices: [total_selected_indices, num_kv_heads]
+            - sparse_attn_offsets: [batch_size + 1] with cumulative indices count
+        """
+        q, k, _ = q.split([
+            self.num_heads * self.head_dim, self.num_kv_heads * self.head_dim,
+            self.num_kv_heads * self.head_dim
+        ],
+                          dim=-1)
+
+        if k is None or metadata is None:
+            return None, None
+
+        num_contexts = metadata.num_contexts
+        num_generations = metadata.num_generations
+        seq_lens = metadata.seq_lens
+        seq_lens_kv = metadata.seq_lens_kv if metadata.seq_lens_kv is not None else seq_lens
+        past_seen_tokens = metadata.kv_cache_params.num_cached_tokens_per_seq
+
+        sparse_attn_indices = []
+        sparse_attn_offsets = [0]
+
+        q_offset = 0
+        k_offset = 0
+
+        for i in range(num_contexts + num_generations):
+            seq_len = seq_lens[i].item()
+            seq_len_kv = seq_lens_kv[i].item()
+
+            if seq_len <= 0 or seq_len_kv <= 0:
+                assert False, "Invalid sequence length"
+
+            single_q = q[q_offset:q_offset + seq_len]
+            single_k = k[k_offset:k_offset + seq_len_kv]
+
+            single_q = single_q.view(1, seq_len, self.num_heads,
+                                     self.head_dim).transpose(1, 2)
+            single_k = single_k.view(1, seq_len_kv, self.num_kv_heads,
+                                     self.head_dim)
+
+            past_seen_token = past_seen_tokens[i]
+            # Generation phase: RocketKV sparse attention indices
+            if i >= num_contexts:
+                _sparse_attn_indices = self._rocketkv_selection(
+                    single_q, single_k, past_seen_token, metadata, i)
+                if _sparse_attn_indices is not None:
+                    sparse_attn_indices.append(
+                        _sparse_attn_indices.squeeze(0))  # [topk, num_kv_heads]
+                    sparse_attn_offsets.append(sparse_attn_offsets[-1] +
+                                               _sparse_attn_indices.size(1))
+                else:
+                    sparse_attn_offsets.append(sparse_attn_offsets[-1])
+
+            q_offset += seq_len
+            k_offset += seq_len_kv
+
+        if len(sparse_attn_indices) == 0:
+            sparse_attn_indices, sparse_attn_offsets = None, None
+        else:
+            sparse_attn_indices = torch.cat(sparse_attn_indices,
+                                            dim=0).to(torch.int32)
+            sparse_attn_offsets = torch.tensor(sparse_attn_offsets,
+                                               dtype=torch.int32).to(q.device)
+        return sparse_attn_indices, sparse_attn_offsets
+
+    def sparse_kv_predict(
+        self, q: torch.Tensor, k: torch.Tensor,
+        metadata: RocketTrtllmAttentionMetadata
+    ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """
+        Predict sparse kv indices.
+
+        For RocketKV:
+        - Context phase: predict SnapKV sparse kv indices
+
+        Returns:
             - flattened_indices: [total_selected_indices, num_kv_heads]
             - batch_offsets: [batch_size + 1] with cumulative indices count
         """
@@ -157,9 +229,7 @@ class RocketTrtllmAttention(TrtllmAttention):
         past_seen_tokens = metadata.kv_cache_params.num_cached_tokens_per_seq
 
         sparse_kv_indices = []
-        sparse_attn_indices = []
         sparse_kv_offsets = [0]
-        sparse_attn_offsets = [0]
 
         q_offset = 0
         k_offset = 0
@@ -191,17 +261,6 @@ class RocketTrtllmAttention(TrtllmAttention):
                                              _sparse_kv_indices.size(1))
                 else:
                     sparse_kv_offsets.append(sparse_kv_offsets[-1])
-            else:
-                # Generation phase: RocketKV sparse attention indices
-                _sparse_attn_indices = self._rocketkv_selection(
-                    single_q, single_k, past_seen_token, metadata, i)
-                if _sparse_attn_indices is not None:
-                    sparse_attn_indices.append(
-                        _sparse_attn_indices.squeeze(0))  # [topk, num_kv_heads]
-                    sparse_attn_offsets.append(sparse_attn_offsets[-1] +
-                                               _sparse_attn_indices.size(1))
-                else:
-                    sparse_attn_offsets.append(sparse_attn_offsets[-1])
 
             q_offset += seq_len
             k_offset += seq_len_kv
@@ -211,17 +270,10 @@ class RocketTrtllmAttention(TrtllmAttention):
         else:
             sparse_kv_indices = torch.cat(sparse_kv_indices,
                                           dim=0).to(torch.int32)
+            sparse_kv_indices = sparse_kv_indices.transpose(0, 1).contiguous()
             sparse_kv_offsets = torch.tensor(sparse_kv_offsets,
                                              dtype=torch.int32).to(q.device)
-        if len(sparse_attn_indices) == 0:
-            sparse_attn_indices, sparse_attn_offsets = None, None
-        else:
-            sparse_attn_indices = torch.cat(sparse_attn_indices,
-                                            dim=0).to(torch.int32)
-            sparse_attn_offsets = torch.tensor(sparse_attn_offsets,
-                                               dtype=torch.int32).to(q.device)
-
-        return sparse_kv_indices, sparse_kv_offsets, sparse_attn_indices, sparse_attn_offsets
+        return sparse_kv_indices, sparse_kv_offsets
 
     def _get_snapkv_indices(self, q: Tensor, k: Tensor, past_seen_token: int,
                             metadata: RocketTrtllmAttentionMetadata,
@@ -802,7 +854,9 @@ class RocketKVCacheManager(KVCacheManager):
             block_ids = self.paged_kt_block_ids[request_ids[i]]
             block_num = len(block_ids)
             kt_block_offsets[i, 0:block_num].copy_(
-                self.base_kt_block_offsets[block_ids])
+                self.base_kt_block_offsets[torch.tensor(block_ids,
+                                                        dtype=torch.int32,
+                                                        device="cpu")])
         return kt_block_offsets
 
     def prepare_resources(self, scheduled_batch):

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1618,8 +1618,11 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         )
 
     def sparse_attn_predict(
-        self, q: torch.Tensor, k: torch.Tensor,
-        metadata: TrtllmAttentionMetadata
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        metadata: TrtllmAttentionMetadata,
+        **kwargs,
     ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
         """
             Predict sparse attn indices. It's implemented in the derived class.
@@ -1627,8 +1630,11 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         raise NotImplementedError
 
     def sparse_kv_predict(
-        self, q: torch.Tensor, k: torch.Tensor,
-        metadata: TrtllmAttentionMetadata
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        metadata: TrtllmAttentionMetadata,
+        **kwargs,
     ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
         """
             Predict sparse kv indices. It's implemented in the derived class.

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1342,11 +1342,10 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
 
         sparse_kv_indices, sparse_kv_offsets, sparse_attn_indices, sparse_attn_offsets = None, None, None, None
         if self.sparse_attention_config is not None:
-            sparse_kv_indices, sparse_kv_offsets, sparse_attn_indices, sparse_attn_offsets = self.sparse_attention_predict(
+            sparse_kv_indices, sparse_kv_offsets = self.sparse_kv_predict(
                 q, k, metadata)
-            if sparse_kv_indices is not None:
-                sparse_kv_indices = sparse_kv_indices.transpose(0,
-                                                                1).contiguous()
+            sparse_attn_indices, sparse_attn_offsets = self.sparse_attn_predict(
+                q, k, metadata)
             if sparse_attn_indices is not None:
                 sparse_attn_indices, sparse_attn_offsets = convert_token_to_page_sparse_indices(
                     sparse_attn_indices, sparse_attn_offsets, metadata)
@@ -1618,10 +1617,20 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             self.mla_params.v_head_dim,
         )
 
-    def sparse_attention_predict(
+    def sparse_attn_predict(
         self, q: torch.Tensor, k: torch.Tensor,
         metadata: TrtllmAttentionMetadata
     ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
         """
-            Predict sparse kv indices and sparse attn indices for the input sequence. It's implemented in the derived class.
+            Predict sparse attn indices. It's implemented in the derived class.
         """
+        raise NotImplementedError
+
+    def sparse_kv_predict(
+        self, q: torch.Tensor, k: torch.Tensor,
+        metadata: TrtllmAttentionMetadata
+    ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """
+            Predict sparse kv indices. It's implemented in the derived class.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
