### PR TITLE
[None][fix] fix rocketkv interface

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -544,82 +544,6 @@ class TrtllmAttentionWrapper:
         )
 
 
-@torch.compile(dynamic=True)
-def convert_token_to_page_sparse_indices(
-        sparse_attn_indices: torch.Tensor, sparse_attn_offsets: torch.Tensor,
-        metadata: 'TrtllmAttentionMetadata'
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Convert token-based sparse attention indices to page-based sparse attention indices.
-
-    Args:
-        sparse_attn_indices: Token-based indices with shape [num_tokens, num_kv_heads]
-        sparse_attn_offsets: Offsets with shape [batch_size+1] indicating token boundaries for each batch
-        metadata: Attention metadata containing tokens_per_block (page_size)
-
-    Returns:
-        Tuple of (page_indices, page_offsets):
-        - page_indices: Page-based indices with shape [num_pages, num_kv_heads]
-        - page_offsets: Updated offsets with shape [batch_size+1] indicating page boundaries for each batch
-
-    Example:
-        If sparse_attn_indices first dimension is [1, 30, 67] and page_size=32,
-        the result will be [0, 2] (token 1 -> page 0, token 30 -> page 0, token 67 -> page 2)
-    """
-    page_size = metadata.tokens_per_block
-    batch_size = sparse_attn_offsets.size(0) - 1
-    num_kv_heads = sparse_attn_indices.size(1)
-
-    # Convert token indices to page indices
-    page_indices = sparse_attn_indices // page_size
-
-    # Process each batch and each kv_head separately to remove duplicates
-    new_page_indices_list = []
-    new_offsets = torch.zeros_like(sparse_attn_offsets)
-
-    current_offset = 0
-    for batch_idx in range(batch_size):
-        start_idx = sparse_attn_offsets[batch_idx]
-        end_idx = sparse_attn_offsets[batch_idx + 1]
-
-        if start_idx >= end_idx:
-            # Empty batch
-            new_offsets[batch_idx + 1] = current_offset
-            continue
-
-        batch_page_indices = page_indices[
-            start_idx:end_idx]  # [num_tokens_in_batch, num_kv_heads]
-
-        # For each kv_head, remove duplicates while preserving order
-        batch_unique_pages = []
-        for head_idx in range(num_kv_heads):
-            head_pages = batch_page_indices[:, head_idx]
-            unique_pages = torch.unique(head_pages, sorted=False)
-            batch_unique_pages.append(unique_pages)
-
-        # Find the maximum length among all heads for this batch
-        max_len = max(pages.size(0) for pages in batch_unique_pages)
-
-        if max_len > 0:
-            batch_result = torch.full((max_len, num_kv_heads),
-                                      fill_value=-1,
-                                      dtype=page_indices.dtype,
-                                      device=page_indices.device)
-
-            for head_idx in range(num_kv_heads):
-                unique_pages = batch_unique_pages[head_idx]
-                batch_result[:unique_pages.size(0), head_idx] = unique_pages
-
-            new_page_indices_list.append(batch_result)
-            current_offset += max_len
-
-        new_offsets[batch_idx + 1] = current_offset
-
-    new_page_indices = torch.cat(new_page_indices_list, dim=0)
-
-    return new_page_indices, new_offsets
-
-
 @dataclass(kw_only=True)
 class TrtllmAttentionMetadata(AttentionMetadata):
     workspace: Optional[torch.Tensor] = None
@@ -1346,11 +1270,6 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 q, k, metadata)
             sparse_attn_indices, sparse_attn_offsets = self.sparse_attn_predict(
                 q, k, metadata)
-            if sparse_attn_indices is not None:
-                sparse_attn_indices, sparse_attn_offsets = convert_token_to_page_sparse_indices(
-                    sparse_attn_indices, sparse_attn_offsets, metadata)
-                sparse_attn_indices = sparse_attn_indices.transpose(
-                    0, 1).contiguous()
 
         self.wrapper.plan(
             layer_idx=self.get_local_layer_idx(metadata),


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
